### PR TITLE
clean writing style loader, path, npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "webpack-dev-server": "^1.14.1"
   },
   "scripts": {
-    "lint": "./node_modules/eslint/bin/eslint.js ./src",
-    "start": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress --color --hot --inline --host 0.0.0.0 --content-base dist/"
+    "lint": "eslint ./src",
+    "start": "webpack-dev-server --progress --color --hot --inline --host 0.0.0.0 --content-base dist/"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,14 +4,14 @@ webpack = require('webpack');
 module.exports = {
   entry: './src/index.js',
   output: {
-    path: __dirname + '/dist/',
+    path: path.resolve('dist/'),
     filename: 'bundle.js'
   },
   module: {
     loaders: [
       {
         test: /.jsx?$/,
-        loader: 'babel-loader',
+        loader: 'babel',
         exclude: /node_modules/
       },
       {


### PR DESCRIPTION
* loader (webpack.config.js): '-loader' is not necessary
* path   (webpack.config.js): '__dirname' is good, 'path.resolve' is the best, because Windows support
* npm scripts (package.json): already prepends the local node_modules/.bin directory to path when executing npm run {scripts}